### PR TITLE
Only serialize one of text and params for PostData

### DIFF
--- a/lib/post-data.js
+++ b/lib/post-data.js
@@ -54,4 +54,12 @@ PostData.prototype.addParam = function (param) {
   return this
 }
 
+PostData.prototype.toJSON = function () {
+  if (this._params.length > 0) {
+    return { mimeType: this.mimeType, params: this.params }
+  } else {
+    return { mimeType: this.mimeType, text: this.text }
+  }
+}
+
 module.exports = PostData


### PR DESCRIPTION
Without this a HAR.log constructed with some request
containing:

new HAR.PostData({
  mimeType: 'application/json',
  text: '{"foo": 1}'
})

will be serialized as
"postData": {
  "mimeType": "application/json",
  "text": "{\"foo\": 1}",
  "params": []
},

and some HAR views will show this as an empty body.

The specification says at
http://www.softwareishard.com/blog/har-12-spec/#postData

"Note that text and params fields are mutually exclusive"